### PR TITLE
Made leaflet selection rate a user-defined variable. Default is set t…

### DIFF
--- a/domhmm/analysis/base.py
+++ b/domhmm/analysis/base.py
@@ -1,8 +1,8 @@
 """
-Elbe --- :mod:`elbe.analysis.Elbe`
+DomHMM --- :mod:`domhmm.analysis.LeafletAnalysisBase`
 ===========================================================
 
-This module contains the :class:`Elbe` class.
+This module contains the :class:`LeafletAnalysisBase` class.
 
 """
 
@@ -83,6 +83,7 @@ class LeafletAnalysisBase(AnalysisBase):
             local: bool = False,
             frac: float = 0.5,
             p_value: float = 0.05,
+            leaflet_frame_rate: int = 1000000,
             **kwargs
     ):
         # the below line must be kept to initialize the AnalysisBase class!
@@ -99,7 +100,7 @@ class LeafletAnalysisBase(AnalysisBase):
         self.heads = heads
         self.tails = tails
         self.sterols = sterols
-        self.leaflet_frame_rate = 10
+        self.leaflet_frame_rate = leaflet_frame_rate
         self.frac = frac
         self.p_value = p_value
 

--- a/domhmm/analysis/domhmm.py
+++ b/domhmm/analysis/domhmm.py
@@ -1,8 +1,8 @@
 """
-LocalFluctuation --- :mod:`elbe.analysis.LocalFluctuation`
+PropertyCalculation --- :mod:`domhmm.analysis.PropertyCalculation`
 ===========================================================
 
-This module contains the :class:`LocalFluctuation` class.
+This module contains the :class:`PropertyCalculation` class.
 
 """
 
@@ -245,6 +245,7 @@ class PropertyCalculation(LeafletAnalysisBase):
         # Calculate correct index if skipping step not equals 1 or start point not equals 0
         self.index = self.frame // self.step - self.start
 
+        #Update leaflet assignment
         if not self.index % self.leaflet_frame_rate:
             self.leaflet_selection = self.get_leaflets()
             assignment_index = int(self.index / self.leaflet_frame_rate)


### PR DESCRIPTION
I made the rate of leaflet selection a user-defined variable. The default is set to an high number so that the leaflet assignment for non-sterolic compounds should be called only once at the start of the analysis.

Changes made in this Pull Request:
 - leaflet_frame_rate is now an argument for `domhmm.analysis.LeafletAnalysisBase`
 - default value is set to 1000000


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
