### PR TITLE
Update base.py

### DIFF
--- a/domhmm/analysis/base.py
+++ b/domhmm/analysis/base.py
@@ -267,6 +267,9 @@ class LeafletAnalysisBase(AnalysisBase):
             leaflet_selection['0'] = self.leaflet_selection_no_sterol['0'] + upper_sterol
             leaflet_selection['1'] = self.leaflet_selection_no_sterol['1'] + lower_sterol
 
+        #If not sterol compound was assigned the leaflet selection is the same as the leaflet selection without sterols
+        if not any(leaflet_selection): leaflet_selection = self.leaflet_selection_no_sterol
+
         return leaflet_selection
 
     def get_resids(self):


### PR DESCRIPTION
Added an if statement to handle simulations with no sterols


<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #

This PR should fix issues with simulation containing no sterolic compounds.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Check if leaflet_selection is an empty dictionary after iteration over sterolic compounds. If empty: leaflet_selection = self.leaflet_selection_without_sterol
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
