### PR TITLE
Fix double counting of residues

### DIFF
--- a/domhmm/analysis/domhmm.py
+++ b/domhmm/analysis/domhmm.py
@@ -374,10 +374,12 @@ class PropertyCalculation(LeafletAnalysisBase):
                     else:
                         # If a residue is %80 of time belongs to a leaflet, accept it as residue of that leaflet
                         lower_leaflet_percentage = len(np.nonzero(leaflet_assign == i)[0]) / len(leaflet_assign)
-                        if lower_leaflet_percentage >= 0.8:
-                            leaflet_train_residx[resname][1].append(idx[i])
-                        elif lower_leaflet_percentage <= 0.2:
-                            leaflet_train_residx[resname][0].append(idx[i])
+                        #if lower_leaflet_percentage >= 0.8:
+                        #    leaflet_train_residx[resname][1].append(idx[i])
+                        #elif lower_leaflet_percentage <= 0.2:
+                        #    leaflet_train_residx[resname][0].append(idx[i])
+                        
+                        #The quick'n'dirty solution is right now to use a threshold of 50% to assign a flipping residue to one leaflet
                         if lower_leaflet_percentage > 0.5:
                             leaflet_residx[resname][1].append(idx[i])
                         else:


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #

This PR relates to the already closed issue: https://github.com/BioMemPhys-FAU/domhmm/issues/34
For asymmetric membranes a mismatch between the shape of the weight matrix and the shape of the order states appear. This probably originated from the changed code section.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - A threshold of 50% was introduced to assign a flipping residue to one leaflet.
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
