### PR TITLE
implement logic of transmembrane domain inclusion into the area per lipid calculation

### DIFF
--- a/domhmm/tests/test_domhmm.py
+++ b/domhmm/tests/test_domhmm.py
@@ -226,8 +226,12 @@ class TestDomhmm:
         boxdim = analysis.universe.trajectory.ts.dimensions[0:3]
         analysis.leaflet_selection_no_sterol = analysis.get_leaflets()
         analysis.leaflet_selection = analysis.get_leaflets_sterol()
-        upper_vor, upper_apl, upper_pbc_idx = analysis.area_per_lipid_vor(leaflet=0, boxdim=boxdim, frac=analysis.frac)
-        lower_vor, lower_apl, lower_pbc_idx = analysis.area_per_lipid_vor(leaflet=1, boxdim=boxdim, frac=analysis.frac)
+        upper_coor_xy = analysis.leaflet_selection[str(0)].positions
+        lower_coor_xy = analysis.leaflet_selection[str(1)].positions
+        upper_vor, upper_apl, upper_pbc_idx = analysis.area_per_lipid_vor(coor_xy=upper_coor_xy, boxdim=boxdim,
+                                                                          frac=analysis.frac)
+        lower_vor, lower_apl, lower_pbc_idx = analysis.area_per_lipid_vor(coor_xy=lower_coor_xy, boxdim=boxdim,
+                                                                          frac=analysis.frac)
         assert np.allclose(apl_results["test_upper_vor"].points, upper_vor.points, error_tolerance)
         assert np.allclose(apl_results["test_upper_apl"], upper_apl, error_tolerance)
         assert np.allclose(apl_results["test_upper_pbc_idx"], upper_pbc_idx, error_tolerance)
@@ -241,9 +245,11 @@ class TestDomhmm:
         """
         analysis.leaflet_selection_no_sterol = analysis.get_leaflets()
         analysis.leaflet_selection = analysis.get_leaflets_sterol()
+        upper_coor_xy = analysis.leaflet_selection[str(0)].positions
+        lower_coor_xy = analysis.leaflet_selection[str(1)].positions
         upper_weight = analysis.weight_matrix(apl_results["test_upper_vor"], pbc_idx=apl_results["test_upper_pbc_idx"],
-                                              leaflet=0)
+                                              coor_xy=upper_coor_xy)
         lower_weight = analysis.weight_matrix(apl_results["test_lower_vor"], pbc_idx=apl_results["test_lower_pbc_idx"],
-                                              leaflet=1)
+                                              coor_xy=lower_coor_xy)
         assert np.allclose(weight_results["test_upper_weight"], upper_weight, error_tolerance)
         assert np.allclose(weight_results["test_lower_weight"], lower_weight, error_tolerance)


### PR DESCRIPTION
- APL and weight matrix functions are converted to static functions
- Transmembrane domain (tmd) logic is implemented and can be usable with `tmd_protein_list` parameter
- Unit tests are updated accordingly
- Documentation update will be handled later
- Unit tests with tmd will be implemented later

Result difference:

Before implementing tmd 
![without-tmd-apl](https://github.com/user-attachments/assets/f4bcb901-dc2f-4cad-a353-0e2bd38c3686)

After implementing tmd
![with-tmd-apl](https://github.com/user-attachments/assets/aecce301-b49d-49a8-bd4a-53cef1d8af9c)

In the example simulation, effects of protein inclusion was limited to a couple of lipids
