### PR TITLE
Update domhmm.py

### DIFF
--- a/domhmm/analysis/domhmm.py
+++ b/domhmm/analysis/domhmm.py
@@ -605,6 +605,12 @@ class PropertyCalculation(LeafletAnalysisBase):
                                  covars_prior=gmm.covariances_,
                                  **hmm_kwargs)
 
+            #Check whether an optimization of the mean vectors and the covariance matrices is requested
+            #Optimization of means is not required  -> Take it from the Gaussian Mixture Model
+            if "m" not in hmm_kwargs['params']: ghmm_i.means_ = gmm.means_
+            #Optimization of covariances is not required -> Take it from the Gaussian Mixture Model
+            if "c" not in hmm_kwargs['params']: ghmm_i.covars_ = gmm.covariances_
+
             # Train the HMM based on the data for every lipid and frame
             ghmm_i.fit(data.reshape(-1, dim),
                        lengths=lengths)


### PR DESCRIPTION
Allow the user to explicitly prevent the HMM from optimizing the means and covariances estimated from the Gaussian Mixture Model.


<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - The function `fit_hmm` checks now if **m** or **c** is stated in the `params` argument to initialise the HMM



PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
