### PR TITLE
Automating LeafletFinder Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With DomHMM you can:
 
 - Calculate the area per lipid for each lipid in every leaflet.
 - Compute the average S<sub>CC</sub> parameter for each acyl chain of every lipid.
-- Easily identify lateral nano- and microdomains in your membrane simulations.
+- Identify lateral nano- and microdomains in your membrane simulations.
 
 Documentation
 --------------
@@ -157,7 +157,6 @@ tails = {"DPPC": [["C1B", "C2B", "C3B", "C4B"], ["C1A", "C2A", "C3A", "C4A"]],
 sterol_heads = {"CHOL": "ROH"}
 sterol_tails = {"CHOL": ["ROH", "C1"]}
 model = domhmm.PropertyCalculation(universe_or_atomgroup=uni,
-                                       leaflet_kwargs={"select": "name PO4", "pbc": True},
                                        membrane_select=membrane_select,
                                        leaflet_select="auto",
                                        heads=heads,

--- a/docs/source/how-to-run.rst
+++ b/docs/source/how-to-run.rst
@@ -14,7 +14,6 @@ DomHMM's main class is ``PropertyCalculation``. In a basic example, it is initia
 .. code-block::
 
     model = domhmm.PropertyCalculation(universe_or_atomgroup=universe,
-                                       leaflet_kwargs=leaflet_kwargs,
                                        membrane_select=membrane_select,
                                        leaflet_select="auto",
                                        heads=heads,
@@ -42,13 +41,6 @@ Let's dive into each parameter's details.
     path2tpr = "YOUR_TPR_FILE.tpr"
     universe = mda.Universe(path2tpr, path2xtc)
 
-* ``leaflet_kwargs`` parameter stands for MDAnalysis ``LeafletFinder`` function's arguments. It is used to determine each leaflet's lipids. ``leaflet_kwargs`` requires head groups of lipids but not sterols.
-
-.. code-block::
-
-    # An example where all lipids head group is PO4
-    leaflet_kwargs={"select": "name PO4", "pbc": True}
-
 * ``membrane_select`` argument is for atom group selection of universe. It is useful for simulations that contain non-membrane residues/molecules inside. If the universe contains only membrane elements, the parameter can be left in the default option which is ``all``
 
 .. code-block::
@@ -56,7 +48,7 @@ Let's dive into each parameter's details.
     # An example where simulation contains DPPC and DIPC lipids, and CHOL sterol
     membrane_select = "resname DPPC DIPC CHOL"
 
-* ``leaflet_select`` argument is a selection option for lipids which can be a list of atom groups, a list of string queries, or automatic via LeafletFinder.
+* ``leaflet_select`` argument is a selection option for lipids which can be a list of atom groups, a list of string queries, or automatic via LeafletFinder. In automatic option, lipid head groups from ``heads`` parameter will be used for leaflet identification or user can setup with ``leaflet_kwargs`` optional parameter.
 
 .. code-block::
 
@@ -142,6 +134,13 @@ Option for saving result plots in pdf format.
 * ``verbose``
 
 Verbose option for debugging. It shows which steps are done in the analysis.
+
+* ``leaflet_kwargs`` parameter stands for MDAnalysis ``LeafletFinder`` function's arguments and used with ``leaflet_select="auto"`` option. It is used to determine each leaflet's lipids. ``leaflet_kwargs`` requires head groups of lipids but not sterols.
+
+.. code-block::
+
+    # An example where all lipids head group is PO4
+    leaflet_kwargs={"select": "name PO4", "pbc": True}
 
 * ``lipid_leaflet_rate``
 

--- a/docs/source/how-to-run.rst
+++ b/docs/source/how-to-run.rst
@@ -200,7 +200,7 @@ Probability value that is used for z-score calculation. It is a determination pe
 
 * ``tmd_protein_list``
 
-Transmembrane domain (TMD) protein list to include area per lipid calculation. TMD proteins take up space in the exoplasmic, cytoplasmic leaflets. Three backbone atoms of protein that are in close position to lipid head groups should be included in this parameter to increase the success of identification.
+Transmembrane domain (TMD) protein list to include area per lipid calculation. TMD proteins take up space in the exoplasmic, cytoplasmic leaflets. Three backbone atoms of protein that are in close position to lipid head groups should be included in this parameter to increase the success of identification. Backbone atoms can be provided by MDAnalysis atom group or a string query for MDAnalysis selection.
 
 .. code-block::
 

--- a/docs/source/post-analysis.rst
+++ b/docs/source/post-analysis.rst
@@ -73,6 +73,6 @@ Users can save and reload the model itself or required data via `pickle`_.
 
 
 .. note::
-    When loading the full model, the MDAnalysis universe will load the trajectory and topology file from the same directory that was given in the analysis run. Therefore, full-model saving can't be loaded if files do not exist.
+    When loading the full model, the MDAnalysis universe will load the trajectory and topology file from the same directory that was given in the analysis run. Therefore, full-model saving may not be loaded from outside of analysis directory.
 
 .. _pickle: https://www.mdanalysis.org/pages/mdakits/

--- a/domhmm/analysis/base.py
+++ b/domhmm/analysis/base.py
@@ -259,24 +259,19 @@ class LeafletAnalysisBase(AnalysisBase):
                             "Entry for each TDM protein should be a dictionary in the format {'0': ..., '1': ...} "
                             "where 0 for lower leaflet and 1 for upper leaflet.")
                     if isinstance(query, AtomGroup):
-                        # Take center of geometry of three positions
-                        cog = np.mean(query.positions, axis=0)
-                        self.tmd_protein[leaflet].append(cog)
+                        self.tmd_protein[leaflet].append(query)
                     # Character string was provided as input, assume it contains a selection for an MDAnalysis.AtomGroup
                     elif isinstance(query, str):
                         # Try to create a MDAnalysis.AtomGroup, raise a ValueError if not selection group could be
                         # provided
                         try:
-                            cog = np.mean(self.universe.select_atoms(query).positions, axis=0)
-                            self.tmd_protein[leaflet].append(cog)
+                            self.tmd_protein[leaflet].append(self.universe.select_atoms(query))
                         except Exception as e:
                             raise ValueError("Please provide a valid MDAnalysis selection string!") from e
                     else:
                         raise ValueError(
                             "TDM Protein list should contain AtomGroup from MDAnalysis universe or a string "
                             "query for MDAnalysis selection.")
-            self.tmd_protein["0"] = np.array(self.tmd_protein["0"])
-            self.tmd_protein["1"] = np.array(self.tmd_protein["1"])
         elif tmd_protein_list is not None:
             # An unknown argument is provided for tdm_protein_list
             raise ValueError(

--- a/domhmm/analysis/base.py
+++ b/domhmm/analysis/base.py
@@ -167,8 +167,7 @@ class LeafletAnalysisBase(AnalysisBase):
         if leaflet_kwargs is not None:
             self.leaflet_kwargs = leaflet_kwargs
         else:
-            unique_head_strs = np.unique(list(heads.values()))
-            select_str_list = [f"name {head_str}" for head_str in unique_head_strs]
+            select_str_list = [f"(name {head_str} and resname {residue_str})" for residue_str, head_str in heads.items()]
             select_str = " or ".join(select_str_list)
             self.leaflet_kwargs = {"select": select_str, "pbc": True}
 

--- a/domhmm/analysis/base.py
+++ b/domhmm/analysis/base.py
@@ -488,17 +488,19 @@ class LeafletAnalysisBase(AnalysisBase):
         """
 
         # Init empty dict to store atom selection of resids
-        # TODO Cause => UserWarning: Empty string to select atoms, empty group returned.
-        #  warnings.warn("Empty string to select atoms, empty group returned.",
-        all_heads = self.universe.select_atoms('')
+        selection_strings = []
 
         # Iterate over found leaflets
         for resname, head in self.heads.items():
-            query_str = f"name {head} and resname {resname}"
-            all_heads = all_heads | self.universe.select_atoms(query_str)
+            selection_strings.append(f"(name {head} and resname {resname})")
         for resname, head in self.sterol_heads.items():
-            query_str = f"name {head} and resname {resname}"
-            all_heads = all_heads | self.universe.select_atoms(query_str)
+            selection_strings.append(f"(name {head} and resname {resname})")
+
+        if selection_strings:
+            all_heads = self.universe.select_atoms(" or ".join(selection_strings))
+        else:
+            all_heads = self.universe.atoms[:0]
+
         return all_heads
 
     def get_sterol_tails(self):

--- a/domhmm/analysis/base.py
+++ b/domhmm/analysis/base.py
@@ -112,7 +112,7 @@ class LeafletAnalysisBase(AnalysisBase):
             membrane_select: str = "all",
             gmm_kwargs: Union[None, dict] = None,
             hmm_kwargs: Union[None, dict] = None,
-            leaflet_kwargs: Dict[str, Any] = {},
+            leaflet_kwargs: Dict[str, Any] = None,
             leaflet_select: Union[None, "AtomGroup", str, list] = None,
             heads: Dict[str, Any] = {},
             tails: Dict[str, Any] = {},
@@ -164,8 +164,14 @@ class LeafletAnalysisBase(AnalysisBase):
         self.parallel_clustering = parallel_clustering
 
         assert heads.keys() == tails.keys(), "Heads and tails don't contain same residue names"
+        if leaflet_kwargs is not None:
+            self.leaflet_kwargs = leaflet_kwargs
+        else:
+            unique_head_strs = np.unique(list(heads.values()))
+            select_str_list = [f"name {head_str}" for head_str in unique_head_strs]
+            select_str = " or ".join(select_str_list)
+            self.leaflet_kwargs = {"select": select_str, "pbc": True}
 
-        self.leaflet_kwargs = leaflet_kwargs
         self.n_leaflets = 0
 
         if gmm_kwargs is None:

--- a/domhmm/analysis/domhmm.py
+++ b/domhmm/analysis/domhmm.py
@@ -321,11 +321,11 @@ class PropertyCalculation(LeafletAnalysisBase):
         lower_coor_xy = self.leaflet_selection[str(1)].positions
         # Check Transmembrane domain existence
         if self.tmd_protein is not None:
-            tmd_upper_coor_xy = self.tmd_protein["0"]
+            tmd_upper_coor_xy = np.array([np.mean(bb.positions, axis=0) for bb in self.tmd_protein["0"]])
             # Check if dimension of coordinates is same in both array
             if tmd_upper_coor_xy.shape[1] == upper_coor_xy.shape[1]:
                 upper_coor_xy = np.append(upper_coor_xy, tmd_upper_coor_xy, axis=0)
-            tmd_lower_coor_xy = self.tmd_protein["1"]
+            tmd_lower_coor_xy = np.array([np.mean(bb.positions, axis=0) for bb in self.tmd_protein["1"]])
             # Check if dimension of coordinates is same in both array
             if tmd_lower_coor_xy.shape[1] == lower_coor_xy.shape[1]:
                 lower_coor_xy = np.append(lower_coor_xy, tmd_lower_coor_xy, axis=0)
@@ -1403,9 +1403,16 @@ class PropertyCalculation(LeafletAnalysisBase):
                               positions[idx, 1],
                               s=100, marker="o", color=colors[j], zorder=-10)
             if self.tmd_protein is not None:
-                label_length += len(self.tmd_protein["0"])
-                for protein in self.tmd_protein["0"]:
-                    ax[k].scatter(protein[0], protein[1], s=100, marker="^", color="black", label="TMD Protein")
+                label_length += 1
+                proteins = np.array([np.mean(bb.positions, axis=0) for bb in self.tmd_protein["0"]])
+                ax[k].scatter(
+                    proteins[:, 0],
+                    proteins[:, 1],
+                    s=100,
+                    marker="^",
+                    color="black",
+                    label="TMD Protein",
+                )
             ax[k].set_xticks([])
             ax[k].set_yticks([])
             ax[k].set_aspect("equal")

--- a/domhmm/tests/test_base.py
+++ b/domhmm/tests/test_base.py
@@ -88,17 +88,6 @@ class TestBase:
         """
         membrane_select, heads, tails, sterol_heads, sterol_tails = self.base_test_inputs()
         # Catch errors for wrong leaflet selection option
-        # Test None input
-        leaflet_select = None
-        with pytest.raises(ValueError):
-            base.LeafletAnalysisBase(universe_or_atomgroup=universe,
-                                     leaflet_kwargs={"select": "name PO4", "pbc": True},
-                                     membrane_select=membrane_select,
-                                     leaflet_select=leaflet_select,
-                                     heads=heads,
-                                     sterol_heads=sterol_heads,
-                                     sterol_tails=sterol_tails,
-                                     tails=tails)
         # Test wrong string input (anything except "auto")
         leaflet_select = "Wrong String"
         with pytest.raises(ValueError):
@@ -178,6 +167,14 @@ class TestBase:
                                  leaflet_kwargs={"select": "name PO4", "pbc": True},
                                  membrane_select=membrane_select,
                                  leaflet_select=leaflet_select,
+                                 heads=heads,
+                                 sterol_heads=sterol_heads,
+                                 sterol_tails=sterol_tails,
+                                 tails=tails)
+        # With auto option and without leaflet kwargs
+        base.LeafletAnalysisBase(universe_or_atomgroup=universe,
+                                 membrane_select=membrane_select,
+                                 leaflet_select="auto",
                                  heads=heads,
                                  sterol_heads=sterol_heads,
                                  sterol_tails=sterol_tails,

--- a/domhmm/tests/test_base.py
+++ b/domhmm/tests/test_base.py
@@ -150,35 +150,49 @@ class TestBase:
         """
         membrane_select, heads, tails, sterol_heads, sterol_tails = self.base_test_inputs()
         # With MDA Query String
-        leaflet_select = ["resid 1:252", "resid 361:612"]
-        base.LeafletAnalysisBase(universe_or_atomgroup=universe,
+        leaflet_select = ["resid 1:252 and name PO4", "resid 361:612 and name PO4"]
+        leaflets_query_string = base.LeafletAnalysisBase(universe_or_atomgroup=universe,
                                  leaflet_kwargs={"select": "name PO4", "pbc": True},
                                  membrane_select=membrane_select,
                                  leaflet_select=leaflet_select,
                                  heads=heads,
                                  sterol_heads=sterol_heads,
                                  sterol_tails=sterol_tails,
-                                 tails=tails)
+                                 tails=tails).leaflet_selection_no_sterol
         # With MDA Atom Group
-        upper_leaflet = universe.select_atoms("resid 1:252")
-        lower_leaflet = universe.select_atoms("resid 361:612")
+        upper_leaflet = universe.select_atoms("resid 1:252 and name PO4")
+        lower_leaflet = universe.select_atoms("resid 361:612 and name PO4")
         leaflet_select = [upper_leaflet, lower_leaflet]
-        base.LeafletAnalysisBase(universe_or_atomgroup=universe,
+        leaflets_atom_group = base.LeafletAnalysisBase(universe_or_atomgroup=universe,
                                  leaflet_kwargs={"select": "name PO4", "pbc": True},
                                  membrane_select=membrane_select,
                                  leaflet_select=leaflet_select,
                                  heads=heads,
                                  sterol_heads=sterol_heads,
                                  sterol_tails=sterol_tails,
-                                 tails=tails)
+                                 tails=tails).leaflet_selection_no_sterol
         # With auto option and without leaflet kwargs
-        base.LeafletAnalysisBase(universe_or_atomgroup=universe,
+        leaflets_auto = base.LeafletAnalysisBase(universe_or_atomgroup=universe,
                                  membrane_select=membrane_select,
                                  leaflet_select="auto",
                                  heads=heads,
                                  sterol_heads=sterol_heads,
                                  sterol_tails=sterol_tails,
-                                 tails=tails)
+                                 tails=tails).leaflet_selection_no_sterol
+        # With auto option and with leaflet kwargs
+        leaflets_auto_w_kwargs = base.LeafletAnalysisBase(universe_or_atomgroup=universe,
+                                                 membrane_select=membrane_select,
+                                                 leaflet_select="auto",
+                                                 leaflet_kwargs={"select": "name PO4", "pbc": True},
+                                                 heads=heads,
+                                                 sterol_heads=sterol_heads,
+                                                 sterol_tails=sterol_tails,
+                                                 tails=tails).leaflet_selection_no_sterol
+
+        assert leaflets_query_string == leaflets_atom_group
+        assert leaflets_query_string == leaflets_auto
+        assert leaflets_query_string == leaflets_auto_w_kwargs
+
 
     def test_tmd_protein_list_exceptions(self, universe):
         """

--- a/domhmm/tests/test_domhmm.py
+++ b/domhmm/tests/test_domhmm.py
@@ -176,9 +176,15 @@ class TestDomhmm:
             assert analysis.results['HMM_Pred']['DPPC'].shape == (302, 100)
             assert analysis.results['HMM_Pred']['DIPC'].shape == (202, 100)
             assert analysis.results['HMM_Pred']['CHOL'].shape == (216, 100)
+
+            # Set the first frame for tmd protein check
+            _ = analysis.universe.trajectory[0]
             assert analysis.tmd_protein.keys() == {'0', '1'}
-            assert np.allclose(analysis.tmd_protein['0'], [[63.04445, 86.886116, 60.87222]], error_tolerance)
-            assert np.allclose(analysis.tmd_protein['1'], [[63.04445,  86.886116, 60.87222 ]], error_tolerance)
+            # Calculate center of geometry of three backbone atoms for both leaflets
+            tmd_upper_coor_xy = np.array([np.mean(bb.positions, axis=0) for bb in analysis.tmd_protein["0"]])
+            tmd_lower_coor_xy = np.array([np.mean(bb.positions, axis=0) for bb in analysis.tmd_protein["1"]])
+            assert np.allclose(tmd_upper_coor_xy, [[63.04445, 86.886116, 60.87222]], error_tolerance)
+            assert np.allclose(tmd_lower_coor_xy, [[63.04445,  86.886116, 60.87222 ]], error_tolerance)
         assert len(analysis.results['HMM_Pred']) == 3
         assert analysis.results['HMM_Pred'].keys() == {'DPPC', 'DIPC', 'CHOL'}
         assert len(analysis.results['Getis_Ord']) == 4

--- a/examples/martini-example/main.py
+++ b/examples/martini-example/main.py
@@ -31,9 +31,7 @@ if __name__ == "__main__":
     sterol_heads = {"CHOL": "ROH"}
     sterol_tails = {"CHOL": ["ROH", "C1"]}
 
-    # leaflet_kwargs should contain all head group molecules of lipids for LeafletFinder function
     model = domhmm.PropertyCalculation(universe_or_atomgroup=universe,
-                                       leaflet_kwargs={"select": "name PO4", "pbc": True},
                                        membrane_select=membrane_select,
                                        leaflet_select="auto",
                                        heads=heads,


### PR DESCRIPTION
- LeafletFinder parameters can be detected automatically if the user selects the `auto` leaflet find option and does not enters `leaflet_kwargs` parameter. 
- Query string consists of all head groups/atoms with their residue names (`(name {head} and resname {resname})`), just in case if user enters different head groups for different lipids. 
- Unit tests and documentation is updated accordingly.
- `get_heads` function is refactored to remove redundant user warning.
- Closes #66 